### PR TITLE
Syntax aware spellchecking

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,12 +2,12 @@
 
 A spellchecking lua plugin for the [vis editor](https://github.com/martanne/vis).
 
-## installation
+## Installation
 
 1. Download `spellcheck.lua` or clone this repository
 2. Load the plugin in your `visrc.lua` with `require(path/to/plugin/spellcheck)`
 
-## usage
+## Usage
 
 + To enable highlighting of misspelled words press `<Ctrl-w>e` in normal mode.
 + To disable highlighting press `<Ctrl-w>d` in normal mode.
@@ -15,7 +15,7 @@ A spellchecking lua plugin for the [vis editor](https://github.com/martanne/vis)
 + To correct the word under the cursor press `<Ctrl+w>w` in normal mode.
 + To ignore the word under the cursor press `<Ctrl+w>i` in normal mode.
 
-## configuration
+## Configuration
 
 The module table returned from `require(...)` has some configuration options:
 
@@ -28,7 +28,7 @@ The module table returned from `require(...)` has some configuration options:
 * `typo_style`: The style string with which misspellings should be highlighted when using the _full viewport_ method
 	* default: `fore:red`
 * `check_tokens`: A table mapping all token names we consider for spellchecking to true
-	* default: `{[vis.lexers.STRING]=true, [vis.lexers.COMMENT]=true}`
+	* default: `{[vis.lexers.STRING]=true, [vis.lexers.COMMENT]=true, [vis.lexers.DEFAULT]=true}`
 * `disable_syntax_awareness`: Disable the syntax aware spellchecking and use always _full viewport_
 	* default: `false`
 

--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,8 @@ The module table returned from `require(...)` has some configuration options:
 	* default: `fore:red`
 * `check_tokens`: A table mapping all token names we consider for spellchecking to true
 	* default: `{[vis.lexers.STRING]=true, [vis.lexers.COMMENT]=true}`
+* `disable_syntax_awareness`: Disable the syntax aware spellchecking and use always _full viewport_
+	* default: `false`
 
 A possible configuration could look like this:
 

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ A spellchecking lua plugin for the [vis editor](https://github.com/martanne/vis)
 
 + To enable highlighting of misspelled words press `<Ctrl-w>e` in normal mode.
 + To disable highlighting press `<Ctrl-w>d` in normal mode.
++ To toggle highlighting press `<F7>` in normal mode.
 + To correct the word under the cursor press `<Ctrl+w>w` in normal mode.
 + To ignore the word under the cursor press `<Ctrl+w>i` in normal mode.
 
@@ -24,8 +25,10 @@ The module table returned from `require(...)` has some configuration options:
 	* default: `enchant -l -d %s` 
 * `lang`: The name of the used dictionary. `lang` is inserted in the cmd-strings at `%s`.
 	* default: `$LANG` or `en_US`
-* `typo_style`: The style string with which misspellings should be highlighted
+* `typo_style`: The style string with which misspellings should be highlighted when using the _full viewport_ method
 	* default: `fore:red`
+* `check_tokens`: A table mapping all token names we consider for spellchecking to true
+	* default: `{[vis.lexers.STRING]=true, [vis.lexers.COMMENT]=true}`
 
 A possible configuration could look like this:
 

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -241,6 +241,8 @@ local enable_spellcheck = function()
 			local old_lex_func = lexer.lex
 			wrapped_lex_funcs[vis.win] = old_lex_func
 			lexer.lex = wrap_lex_func(old_lex_func)
+			-- reset last data to enforce new highlighting
+			last_data = ""
 			return
 		end
 	end

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -53,7 +53,7 @@ local function get_typos(range_or_text)
 			return nil
 		end
 
-		local tmp_file = io.open(tmp_name, "r")
+		local tmp_file = assert(io.open(tmp_name, "r"))
 		typos = tmp_file:read("*a")
 		tmp_file:close()
 		os.remove(tmp_name)
@@ -304,7 +304,7 @@ vis:map(vis.modes.NORMAL, "<C-w>w", function(keys)
 
 	-- select a correction
 	local cmd = 'printf "' .. suggestions:gsub(", ", "\\n") .. '\\n" | vis-menu'
-	local f = io.popen(cmd)
+	local f = assert(io.popen(cmd))
 	local correction = f:read("*all")
 	f:close()
 	-- trim correction

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -91,6 +91,13 @@ local function typo_iter(text, typos, ignored)
 			-- ("stuff stuf", "broken ok", ...)
 			-- we match typos only when they are enclosed in non-letter characters.
 			local start, finish = text:find("[%A]" .. typo .. "[%A]", index)
+			-- the typo was not found by our pattern this means it must be the last word in the text
+			if not start then
+				start, finish = text:find("[%A]" .. typo .. "$", index)
+				if not start then
+					vis:info(string.format("typo %s not found after %d this must be a bug please report", typo, index))
+				end
+			end
 			index = finish
 
 			-- ignore the first and last non letter character

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -86,9 +86,14 @@ local function typo_iter(text, typos, ignored)
 		until(not typo or not ignored[typo])
 
 		if typo then
-			local start, finish = text:find(typo, index, true)
+			-- to prevent typos from being found in correct words before them
+			-- ("stuff stuf", "broken ok", ...)
+			-- we match typos only when they are enclosed in non-letter characters.
+			local start, finish = text:find("[%A]" .. typo .. "[%A]", index)
 			index = finish
-			return typo, start, finish
+
+			-- ignore the first and last non letter character
+			return typo, start + 1, finish - 1
 		end
 	end
 end

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -84,9 +84,9 @@ local function typo_iter(text, typos, ignored)
 	return function(foo, bar)
 		repeat
 			typo = unfiltered_iterator(iter_state)
-		until(not typo or not ignored[typo])
+		until(not typo or (typo ~= "" and not ignored[typo]))
 
-		if typo and typo ~= "" then
+		if typo then
 			-- to prevent typos from being found in correct words before them
 			-- ("stuff stuf", "broken ok", ...)
 			-- we match typos only when they are enclosed in non-letter characters.

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -134,6 +134,9 @@ vis.events.subscribe(vis.events.WIN_HIGHLIGHT, function(win)
 		typos = last_typos
 	else
 		typos = get_typos(viewport) or ""
+		if not typos then
+			return false
+		end
 	end
 
 	for typo, start, finish in typo_iter(viewport_text, typos, ignored) do
@@ -166,6 +169,9 @@ local wrap_lex_func = function(old_lex_func)
 		if last_data ~= data
 		then
 			typos = get_typos(data)
+			if not typos then
+				return tokens, timedout
+			end
 			last_data = data
 		else
 			return old_new_tokens

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -3,17 +3,19 @@
 
 local spellcheck = {}
 spellcheck.lang = os.getenv("LANG"):sub(0,5) or "en_US"
-local supress_output = ">/dev/null 2>/dev/null"
-if os.execute("type enchant "..supress_output) then
+local supress_stdout = " >/dev/null"
+local supress_stderr = " 2>/dev/null"
+local supress_output = supress_stdout .. supress_stderr
+if os.execute("type enchant"..supress_output) then
 	spellcheck.cmd = "enchant -d %s -a"
 	spellcheck.list_cmd = "enchant -l -d %s -a"
-elseif os.execute("type enchant-2 "..supress_output) then
+elseif os.execute("type enchant-2"..supress_output) then
 	spellcheck.cmd = "enchant-2 -d %s -a"
 	spellcheck.list_cmd = "enchant-2 -l -d %s -a"
-elseif os.execute("type aspell "..supress_output) then
+elseif os.execute("type aspell"..supress_output) then
 	spellcheck.cmd = "aspell -l %s -a"
 	spellcheck.list_cmd = "aspell list -l %s -a"
-elseif os.execute("type hunspell "..supress_output) then
+elseif os.execute("type hunspell"..supress_output) then
 	spellcheck.cmd = "hunspell -d %s"
 	spellcheck.list_cmd = "hunspell -l -d %s"
 else

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -28,9 +28,9 @@ spellcheck.disable_syntax_awareness = false
 
 spellcheck.check_tokens = {
 	[vis.lexers.STRING] = true,
-	[vis.lexers.COMMENT] = true
+	[vis.lexers.COMMENT] = true,
+	[vis.lexers.DEFAULT] = true,
 }
-
 
 -- Return nil or a string of misspelled word in a specific file range or text
 -- by calling the spellchecker's list command.

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -81,6 +81,31 @@ local ignored = {}
 local function typo_iter(text, typos, ignored)
 	local index = 1
 	local unfiltered_iterator, iter_state = typos:gmatch("(.-)\n")
+
+-- see https://stackoverflow.com/questions/6705872/how-to-escape-a-variable-in-lua
+	local escape_lua_pattern
+	do
+		local matches =
+			{
+				["^"] = "%^";
+				["$"] = "%$";
+				["("] = "%(";
+				[")"] = "%)";
+				["%"] = "%%";
+				["."] = "%.";
+				["["] = "%[";
+				["]"] = "%]";
+				["*"] = "%*";
+				["+"] = "%+";
+				["-"] = "%-";
+				["?"] = "%?";
+			}
+
+		escape_lua_pattern = function(s)
+			return (s:gsub(".", matches))
+		end
+	end
+
 	return function(foo, bar)
 		repeat
 			typo = unfiltered_iterator(iter_state)
@@ -90,7 +115,7 @@ local function typo_iter(text, typos, ignored)
 			-- to prevent typos from being found in correct words before them
 			-- ("stuff stuf", "broken ok", ...)
 			-- we match typos only when they are enclosed in non-letter characters.
-			local start, finish = text:find("[%A]" .. typo .. "[%A]", index)
+			local start, finish = text:find("[%A]" .. escape_lua_pattern(typo) .. "[%A]", index)
 			-- typo was not found by our pattern this means it must be either
 			-- the first or last word in the text
 			if not start then

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -75,8 +75,8 @@ end
 local ignored = {}
 
 -- Return an iterator over all not ignored typos and their positions in text.
--- The returned iterator is a seelf contained statefull iterator function closure.
--- Which will return the next typo and ist start and finish in the text, starting by 1.
+-- The returned iterator is a self contained statefull iterator function closure.
+-- Which will return the next typo and its start and finish in the text, starting by 1.
 local function typo_iter(text, typos, ignored)
 	local index = 0
 	local unfiltered_iterator, iter_state = typos:gmatch("(.-)\n")

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -205,7 +205,7 @@ local wrap_lex_func = function(old_lex_func)
 					table.insert(new_tokens, vis.lexers.ERROR)
 					table.insert(new_tokens, typo_end + 1)
 				end
-			until(not token_end or token_end > typo_end)
+			until(not token_end or token_end >= typo_end)
 		end
 
 		-- add tokens left after we handled all typos

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -123,7 +123,6 @@ local wrapped_lex_funcs = {}
 
 local wrap_lex_func = function(old_lex_func)
 	return function(lexer, data, index, redrawtime_max)
-		-- vis:info("hooked lexer.lex")
 		local tokens, timedout = old_lex_func(lexer, data, index, redrawtime_max)
 
 		-- quit early if the lexer already took to long
@@ -133,9 +132,7 @@ local wrap_lex_func = function(old_lex_func)
 			return tokens, timedout
 		end
 
-		local log = nil
 		local win = vis.win
-		local cmd = spellcheck.list_cmd:format(spellcheck.lang)
 		local new_tokens = {}
 
 		-- get file position we lex

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -95,19 +95,19 @@ local function typo_iter(text, typos, ignored)
 			-- the first or last word in the text
 			if not start then
 				-- check start of text
-				if index == 1 then
-					start = index
-					finish = #typo
-				-- must be the end of text
-				else
+				start = 1
+				finish = #typo
+				-- typo is not the beginning must be the end of text
+				if text:sub(start, finish) ~= typo then
 					start = #text - #typo + 1
 					finish = start + #typo - 1
 				end
 
 				if text:sub(start, finish) ~= typo then
-					vis:info(string.format("typo %s not where expected after %d at %d %d found: %s",
-						typo, index, start, finish, text:sub(start, finish)))
+					vis:info(string.format("can't find typo %s after %d. Please report this bug.",
+										   typo, index))
 				end
+			-- our pettern [%A]typo[%A] found it
 			else
 				start = start + 1 -- ignore leading non letter char
 				finish = finish - 1 -- ignore trailing non letter char

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -203,7 +203,13 @@ local wrap_lex_func = function(old_lex_func)
 
 					-- highlight typo
 					table.insert(new_tokens, vis.lexers.ERROR)
-					table.insert(new_tokens, typo_end + 1)
+					-- the typo spans multiple tokens
+					if token_end < typo_end then
+						table.insert(new_tokens, token_end + 1)
+						i = i + 2
+					else
+						table.insert(new_tokens, typo_end + 1)
+					end
 				end
 			until(not token_end or token_end >= typo_end)
 		end

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -24,6 +24,7 @@ end
 
 spellcheck.typo_style = "fore:red"
 spellcheck.check_full_viewport = {}
+spellcheck.disable_syntax_awareness = false
 
 spellcheck.check_tokens = {
 	[vis.lexers.STRING] = true,
@@ -203,7 +204,7 @@ local enable_spellcheck = function()
 		return
 	end
 
-	if vis.win.syntax and vis.lexers.load then
+	if not spellcheck.disable_syntax_awareness and vis.win.syntax and vis.lexers.load then
 		local lexer = vis.lexers.load(vis.win.syntax, nil, true)
 		if lexer and lexer.lex then
 			local old_lex_func = lexer.lex

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -119,7 +119,7 @@ local function typo_iter(text, typos, ignored)
 	end
 end
 
-local last_viewport, last_typos = nil, ""
+local last_viewport, last_data, last_typos = nil, "", ""
 
 vis.events.subscribe(vis.events.WIN_HIGHLIGHT, function(win)
 	if not spellcheck.check_full_viewport[win] or not win:style_define(42, spellcheck.typo_style) then
@@ -148,8 +148,7 @@ end)
 local wrapped_lex_funcs = {}
 
 local wrap_lex_func = function(old_lex_func)
-	local old_data = ""
-	local old_new_tokens = ""
+	local old_new_tokens = {}
 
 	return function(lexer, data, index, redrawtime_max)
 		local tokens, timedout = old_lex_func(lexer, data, index, redrawtime_max)
@@ -164,10 +163,10 @@ local wrap_lex_func = function(old_lex_func)
 		local new_tokens = {}
 
 		local typos = ""
-		if old_data ~= data
+		if last_data ~= data
 		then
 			typos = get_typos(data)
-			old_data = data
+			last_data = data
 		else
 			return old_new_tokens
 		end
@@ -351,8 +350,10 @@ end, "Ignore misspelled word")
 vis:option_register("spelllang", "string", function(value, toggle)
 	spellcheck.lang = value
 	vis:info("Spellchecking language is now "..value)
-	-- force new highlight
+	-- force new highlight for full viewport
 	last_viewport = nil
+	-- force new highlight for syntax aware
+	last_data = nil
 	return true
 end, "The language used for spellchecking")
 

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -86,7 +86,7 @@ local function typo_iter(text, typos, ignored)
 			typo = unfiltered_iterator(iter_state)
 		until(not typo or not ignored[typo])
 
-		if typo then
+		if typo and typo ~= "" then
 			-- to prevent typos from being found in correct words before them
 			-- ("stuff stuf", "broken ok", ...)
 			-- we match typos only when they are enclosed in non-letter characters.


### PR DESCRIPTION
## Current state
Hijacking the lexer's `lex` function and inserting our typo highlighting into the token stream works.  
The algorithm now calls the external spellchecker at most once per `lex` run which is much faster than calling it for each token we want to spellcheck. I would consider it usable but the performance could still be improved.

## TODO
- [ ]  improve how tokens are considered for spellchecking (normal code files like C or lua should work but mostly text files like markdown/latex or diffs are not spellchecked currently). One solution would be a curated list of tokens per syntax and a fallback.
- [ ]  maybe make the emitted token type configurable or introduce a new one (how would it get styled?)
- [ ]  test if only spellchecking the content of the tokens we want to check brings a performance advantage

It would be great if you could try it and tell me your oppinon @Mikmert ;)