### PR TITLE
Fix arrows in vis-menu by using vis:pipe()

### DIFF
--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -348,12 +348,10 @@ vis:map(vis.modes.NORMAL, "<C-w>w", function(keys)
 
 	-- select a correction
 	local cmd = 'printf "' .. suggestions:gsub(", ", "\\n") .. '\\n" | vis-menu'
-	local f = assert(io.popen(cmd))
-	local correction = f:read("*all")
-	f:close()
-	-- trim correction
-	correction = correction:match("^%s*(.-)%s*$")
-	if correction ~= "" then
+	local status, correction = vis:pipe(file, {start = 0, finish = 0}, cmd)
+	if status == 0 then
+		-- trim correction
+		correction = correction:match("^%s*(.-)%s*$")
 		win.file:delete(range)
 		win.file:insert(range.start, correction)
 	end


### PR DESCRIPTION
Arrow keys didn't work in [my terminal](https://codeberg.org/dnkl/foot), and replacing io.popen with vis:pipe fixed it.