### PR TITLE
check if "LANG" environment variable exists before indexing it

### DIFF
--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -2,7 +2,11 @@
 -- Use of this source code is governed by a MIT license found in the LICENSE file.
 
 local spellcheck = {}
-spellcheck.lang = os.getenv("LANG"):sub(0,5) or "en_US"
+if os.getenv("LANG") then
+	spellcheck.lang = os.getenv("LANG"):sub(0,5)
+else
+	spellcheck.lang = "en_US"
+end
 local supress_stdout = " >/dev/null"
 local supress_stderr = " 2>/dev/null"
 local supress_output = supress_stdout .. supress_stderr


### PR DESCRIPTION
The plugin will fail to load if LANG is not set. A check like this will fix it.

I don't really write lua very often so I don't know if there is a more common idiom for doing this sort of check. It can be changed if there is.