### PR TITLE
Use 'vis.win.file.spell_language' rather than 'spellcheck.lang'

### DIFF
--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -435,4 +435,8 @@ vis:option_register('spelllang', 'string', function(value)
   return true
 end, 'The language used for spellchecking')
 
+vis:command_register('spelllang', function(value)
+  vis:info('The spellchecking language is ' .. spellcheck.get_lang())
+end, 'Print the language used for spellchecking')
+
 return spellcheck


### PR DESCRIPTION
There is some discussion on the editorconfig side
about whether a 'spell_language' key could be added
(cf. https://github.com/editorconfig/editorconfig/issues/315,
https://github.com/seifferth/vis-editorconfig/pull/8). This key would
specify the natural language a file is written in and it would then
be up to the editor or plugin doing the spellchecking to respect that
setting and behave accordingly.

Since it is out of the scope of the vis-editorconfig plugin to
implement spellchecking, and since I would like the vis-editorconfig
plugin to work both with and without vis-spellcheck, I suggest
to use 'vis.win.file.spell_language' to store the document
language. With commit 0ee415c in the vis-editorconfig repo
(https://github.com/seifferth/vis-editorconfig), this value is already
set to the appropriate value. This commit adjusts the spellchecking
plugin to use the same global value. I did some testing that suggests
it should work.

There might still be some hickups if 'vis.win.file' does not exist.
This is a non-issue for editorconfig, since editorconfig only works
if 'vis.win.file.path' exists (which configuration is used depends
on the path). The Readme would also need some adjustment.