### PR TITLE
add keybind to add word to user dictionary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ A spellchecking lua plugin for the [vis editor](https://github.com/martanne/vis)
 + To toggle highlighting press `<F7>` in normal mode.
 + To correct the word under the cursor press `<Ctrl+w>w` in normal mode.
 + To ignore the word under the cursor press `<Ctrl+w>i` in normal mode.
++ To add the word under the cursor to the user dictionary press '<Ctrl+w>a' in normal mode.
 
 ## Configuration
 

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -396,7 +396,7 @@ vis:map(vis.modes.NORMAL, '<C-w>w', function()
   return 0
 end, 'Correct misspelled word')
 
-vis:map(vis.modes.NORMAL, '<C-w>i', function()
+local ignore = function()
   local win = vis.win
   local file = win.file
   local pos = win.selection.pos
@@ -425,6 +425,10 @@ vis:map(vis.modes.NORMAL, '<C-w>i', function()
   end
 
   win:draw()
+end
+
+vis:map(vis.modes.NORMAL, '<C-w>i', function()
+  ignore()
   return 0
 end, 'Ignore misspelled word')
 
@@ -442,7 +446,14 @@ vis:map(vis.modes.NORMAL, '<C-w>a', function()
 
   local cmd = string.format(':!echo "*%s\\n#" | %s', file:content(range),
                             spellcheck.cmd:format(spellcheck.get_lang()))
-  return vis:command(cmd)
+
+  if not vis:command(cmd) then
+    vis:info('executing vis command: "' .. cmd .. '" failed')
+  end
+
+  -- ignore the added word to prevent it from being highlighted in this session
+  ignore()
+  return 0
 end, 'Add word to user dictionary')
 
 vis:option_register('spelllang', 'string', function(value)

--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -428,6 +428,23 @@ vis:map(vis.modes.NORMAL, '<C-w>i', function()
   return 0
 end, 'Ignore misspelled word')
 
+vis:map(vis.modes.NORMAL, '<C-w>a', function()
+  local file = vis.win.file
+  local pos = vis.win.selection.pos
+  if not pos then
+    return
+  end
+
+  local range = file:text_object_word(pos);
+  if not range or range.start == range.finish then
+    return
+  end
+
+  local cmd = string.format(':!echo "*%s\\n#" | %s', file:content(range),
+                            spellcheck.cmd:format(spellcheck.get_lang()))
+  return vis:command(cmd)
+end, 'Add word to user dictionary')
+
 vis:option_register('spelllang', 'string', function(value)
   vis.win.file.spell_language = value
   vis:info('Spellchecking language is now ' .. value)


### PR DESCRIPTION
I write a lot of scientific papers in vis and it was getting tedious to add domain specific terms to my dictionary so I added a keybinding (`<Ctrl-w>a`).

Note: this won't recheck the viewport after adding the word since I didn't see a clean way of doing that in the code. Just calling `win:draw()` doesn't work since nothing in the viewport has changed.