### PR TITLE
Rename 'spell_language' to 'spelling_language'

### DIFF
--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -7,8 +7,8 @@ if not spellcheck.default_lang:match('^[a-z][a-z]_[A-Z][A-Z]$') then
 end
 
 spellcheck.get_lang = function()
-  if vis.win.file.spell_language then
-    return vis.win.file.spell_language
+  if vis.win.file.spelling_language then
+    return vis.win.file.spelling_language
   else
     return spellcheck.default_lang
   end


### PR DESCRIPTION
Following discussions on the editorconfig standard, I just renamed this property in the vis-editorconfig plugin (see https://github.com/seifferth/vis-editorconfig/commit/d99ec6bb31b042bf0b6111c20d622f64636d2ed6). In order to keep the naming somewhat consistent, I also updated the internal variable name that stores the spelling_language specified in editorconfig files. This commit updates the spellcheck plugin to use the updated variable name.