### PR TITLE
Turn on highlighting when suggestions keybinding Ctrl-W W is pressed

### DIFF
--- a/spellcheck.lua
+++ b/spellcheck.lua
@@ -331,6 +331,9 @@ vis:map(vis.modes.NORMAL, '<F7>', function()
 end, 'Toggle spellchecking in the current window')
 
 vis:map(vis.modes.NORMAL, '<C-w>w', function()
+  -- Turn on highlighting
+  enable_spellcheck()
+
   local win = vis.win
   local file = win.file
   local pos = win.selection.pos


### PR DESCRIPTION
This helps users view other spelling errors after running `Ctrl-W W` for the first time.

I can make a PR into https://gitlab.com/muhq/vis-spellcheck if this is preferred.